### PR TITLE
Race condition fix and scd1/scd2 implementation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install package + dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run test suite
+        run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -665,6 +665,70 @@ for salesforce_object in salesforce_objects:
 - **Performance**: More efficient than JSON parsing for large datasets
 - **Field-Level Access**: Direct access to individual Salesforce fields as columns
 
+### Accurate Current State and SCD2 History
+
+The deployed `lakeflow_declarative_pipeline.py` extends the parsing snippet above
+to also maintain, **per Salesforce object**:
+
+| Table | Type | Description |
+|-------|------|-------------|
+| `salesforce_current_<obj>` | Type-1 current state | One row per record with accurate latest values |
+| `salesforce_history_<obj>` | SCD2 history | Full history with `__START_AT` / `__END_AT` |
+
+**Why this needs more than a `@dp.table` or `create_auto_cdc_flow`.** Salesforce
+CDC update events are *sparse* — only changed fields are meaningful — and because
+the payload is Avro, every field is always present, so an **unchanged** field and
+a field **changed to null** both decode as `null`. The only authoritative signal
+is the change mask: `changed_fields` / `nulled_fields` / `diff_fields`.
+`create_auto_cdc_flow`'s `ignore_null_updates` keys off the value being `null`, so
+it cannot tell unchanged-null from changed-to-null. The pipeline therefore applies
+a per-column **conditional MERGE** inside a `@dp.foreach_batch_sink`:
+
+- field **unchanged** → existing target value carried forward
+- field **changed to null** → written as `NULL`
+- field **changed to value** → written with the new value
+
+`salesforce_current_<obj>` has Change Data Feed enabled; Layer 2 reads that CDF
+(now full, correct row images) into `salesforce_history_<obj>` via
+`create_auto_cdc_flow` with `stored_as_scd_type=2`.
+
+```sql
+-- accurate latest state
+SELECT Id, Email, Phone, _last_change_type, _updated_at
+FROM salesforce_current_Contact ORDER BY _updated_at DESC LIMIT 20;
+
+-- point-in-time history
+SELECT Id, Email, __START_AT, __END_AT
+FROM salesforce_history_Contact WHERE Id = '<record id>' ORDER BY __START_AT;
+```
+
+**Notes**
+- `salesforce_current_<obj>` is an **external** Delta table (not a pipeline-managed
+  node), so it is **not** reset by a full refresh. The pipeline creates it itself
+  during graph evaluation via the **DeltaTable builder API** (`DeltaTable.createIfNotExists`)
+  — `spark.sql("CREATE TABLE …")` is rejected during SDP graph evaluation, but the
+  builder API is allowed. Creating it at eval (rather than in the sink at runtime)
+  is required because the SCD2 CDF reader references the table by name and must
+  resolve it at flow-analysis time, before any flow runs.
+- **History trails current by at most one update** in triggered/dev runs: within a
+  single update the CDF reader can finish before the sink commits its MERGE, so the
+  new change is picked up on the next update. In continuous production this is a
+  one-microbatch lag that self-heals; for a dev/triggered run, trigger once more to
+  let history catch up.
+- **Schema evolution**: restart the pipeline (not a full refresh) to pick up the
+  latest Avro schema; new fields are captured after the current table is recreated.
+- **`diff_fields` (large text ≥ 1000 chars, e.g. `Description`)** are sent by
+  Salesforce CDC as a **unified diff**, not the full value. The sink **reconstructs**
+  the full value by folding each record's per-batch change chain in sequence order
+  (full-value and diff events) and applying the unified diff to the prior value via
+  the `resolve_chain` UDF. The value is split/rejoined on its own line terminator
+  (CRLF-aware) and verified against the SHA-256 in the diff's `+++` header; on
+  mismatch (or when no prior full value exists to apply the diff to) it falls back to
+  the last full value rather than storing diff text. A one-time full extract would
+  seed bases for records whose long text was set before CDC capture.
+- **`current_cdf_<obj>`** is a `@dp.temporary_view` (pipeline-scoped, not
+  materialized), used only as the streaming CDF source for the SCD2 flow.
+
 
 ### Regenerating Protocol Buffer Files
 

--- a/lakeflow_declarative_pipeline.py
+++ b/lakeflow_declarative_pipeline.py
@@ -1,42 +1,414 @@
+"""Salesforce CDC -> accurate current state (Type 1) + SCD2 history, in one SDP pipeline.
+
+Salesforce Change Data Capture sends *sparse* update events: only changed fields
+are meaningful, and because the payload is Avro (every field is always present),
+an unchanged field and a field genuinely changed-to-null both decode as `null`.
+The only authoritative signal for what changed is the change mask carried in the
+bronze columns `changed_fields` / `nulled_fields` / `diff_fields`.
+
+A plain @dp.table cannot produce accurate final state (it returns a DataFrame and
+cannot express "keep the existing value for fields not in the change mask"), and
+create_auto_cdc_flow's `ignore_null_updates` keys off the value being null so it
+can't tell unchanged-null from changed-to-null. The correct primitive is a
+conditional MERGE, run inside the pipeline via a ForEachBatch sink.
+
+Per Salesforce object this builds:
+  Layer 1  salesforce_current_<obj>  - Type-1 accurate current state
+           (@dp.append_flow parses Avro inline -> @dp.foreach_batch_sink MERGE).
+           External Delta table with Change Data Feed enabled.
+  Layer 2  salesforce_history_<obj>  - SCD2 history
+           (@dp.table reads the current table's CDF -> create_auto_cdc_flow).
+           Lags Layer 1 by one update under a TRIGGERED cadence: Layer 2's CDF
+           reader is a streaming source that snapshots the current table at the
+           start of each update, before Layer 1's MERGE in that same update
+           commits. So a change written to the current table in update N first
+           appears in history in update N+1. Harmless under continuous:true (the
+           lag is one micro-batch and self-heals); only visible when triggered
+           updates complete and the pipeline goes IDLE between them. When testing
+           after a source change, expect history to reflect it one update later.
+
+NOTE: salesforce_current_<obj> is an *external* Delta table (not a pipeline-managed
+node), so it is not reset by full refresh. The sink creates it (CDF on) on its
+first micro-batch and merges into it; SDP forbids CREATE TABLE during graph
+evaluation but allows it inside the sink's runtime micro-batch. On a brand new
+object the Layer 2 CDF reader can fail once at startup (table not yet created) and
+recovers on SDP's flow retry. Run the pipeline (not a full refresh) when the Avro
+schema evolves; new fields are only picked up after the current table is recreated.
+"""
+
+import hashlib
+import re
+
+from delta.tables import DeltaTable
 from pyspark import pipelines as dp
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
 from pyspark.sql.avro.functions import from_avro
-from pyspark.sql.functions import col, desc
+from pyspark.sql.functions import array_contains, array_union, col, desc, expr, lit, max_by
+from pyspark.sql.types import LongType, StringType, StructField, StructType, TimestampType
 
-# .collects() are generally not recommended in LDP, but becuase the list of Salesforce objects is small it is okay here.
+spark = SparkSession.getActiveSession()
+
+# Bronze table written by the salesforce-zerobus streamer.
+zerobus_table = "alexn.salesforce.zb_contact"
+CATALOG, SCHEMA, _ = zerobus_table.split(".")
+
+# Bronze columns that are CDC metadata, not Salesforce business fields. Everything
+# else after Avro parsing (minus the ChangeEventHeader struct) is a business field.
+META_COLS = {
+    "event_id", "schema_id", "replay_id", "timestamp", "change_type", "entity_name",
+    "change_origin", "record_ids", "changed_fields", "nulled_fields", "diff_fields",
+    "record_data_json", "payload_binary", "schema_json", "org_id", "processed_timestamp",
+    "ChangeEventHeader",
+}
+
+# change_type values that carry a full image with an empty change mask; for these,
+# treat every populated field as "changed".
+CREATE_LIKE = ("CREATE", "UNDELETE", "GAP_CREATE", "GAP_UNDELETE", "GAP_OVERFLOW")
 
 
-def create_pipeline(salesforce_object):
-    @dp.table(name=f"salesforce_parsed_{salesforce_object}")
-    def parse_salesforce_stream():
-        df = dp.readStream(zerobus_table).filter(
-            col("entity_name") == salesforce_object
+def _safe(obj: str) -> str:
+    """Object name -> safe identifier suffix for table/flow/sink names."""
+    return re.sub(r"\W+", "_", obj)
+
+
+def _latest_schema_json(obj: str):
+    """Most recent Avro schema for an object, or None if it has no payload yet."""
+    row = (
+        dp.read(zerobus_table)
+        .filter(
+            (col("entity_name") == obj)
+            & col("payload_binary").isNotNull()
+            & col("schema_json").isNotNull()
         )
+        .orderBy(desc("timestamp"))
+        .select("schema_json")
+        .first()
+    )
+    return row[0] if row else None
 
-        latest_schema = (
-            dp.read(zerobus_table)
-            .filter(
-                (col("entity_name") == salesforce_object)
-                & (col("payload_binary").isNotNull())
-                & (col("schema_json").isNotNull())
+
+def _parse_avro(df, schema_json):
+    """Flatten the Avro payload into typed business columns alongside the metadata."""
+    return (
+        df.select("*", from_avro(col("payload_binary"), schema_json, {"mode": "PERMISSIVE"}).alias("p"))
+        .select("*", "p.*")
+        .drop("p")
+    )
+
+
+_HUNK_RE = re.compile(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def _parse_unified_diff(diff_lines):
+    """Split raw diff lines into (expected_hash, hunks).
+
+    `expected_hash` is the SHA-256 carried in the `+++` header (or None). Each hunk is
+    a (old_start, body_lines) pair, where old_start is the 1-based line in the previous
+    value where the hunk begins and body_lines are its `' '`/`'-'`/`'+'` content lines.
+
+    Returns None if a hunk header is malformed (the caller then keeps the prior value)."""
+    expected_hash = None
+    hunks = []
+    pos, total = 0, len(diff_lines)
+    while pos < total:
+        line = diff_lines[pos]
+        if line.startswith("+++ "):
+            expected_hash = line[4:].strip() or None
+            pos += 1
+        elif line.startswith("@@"):
+            match = _HUNK_RE.match(line)
+            if not match:
+                return None
+            old_start = int(match.group(1))
+            pos += 1
+            body = []
+            while pos < total:
+                body_line = diff_lines[pos]
+                if body_line[:2] == "@@" or body_line[:4] in ("--- ", "+++ "):
+                    break  # start of the next hunk/header
+                if body_line == "" and pos == total - 1:
+                    pos += 1  # trailing artifact from split("\n")
+                    continue
+                body.append(body_line)
+                pos += 1
+            hunks.append((old_start, body))
+        else:
+            pos += 1  # "--- " header or any line outside a hunk
+    return expected_hash, hunks
+
+
+def _rebuild_from_hunks(prev_lines, hunks):
+    """Apply parsed hunks to the previous value's lines, returning the new lines.
+
+    Returns None on an unrecognized body line (the caller then keeps the prior value)."""
+    result = []
+    prev_idx = 0  # 0-based cursor into prev_lines
+    for old_start, body in hunks:
+        # Copy the unchanged lines that precede this hunk verbatim.
+        while prev_idx < old_start - 1 and prev_idx < len(prev_lines):
+            result.append(prev_lines[prev_idx])
+            prev_idx += 1
+        for body_line in body:
+            tag = body_line[0] if body_line else " "
+            if tag == " ":  # context: keep the prior line (fall back to diff text)
+                result.append(prev_lines[prev_idx] if prev_idx < len(prev_lines) else body_line[1:])
+                prev_idx += 1
+            elif tag == "-":  # removal: drop the prior line
+                prev_idx += 1
+            elif tag == "+":  # addition: emit the new line
+                result.append(body_line[1:])
+            else:
+                return None
+    # Copy any unchanged lines after the last hunk.
+    while prev_idx < len(prev_lines):
+        result.append(prev_lines[prev_idx])
+        prev_idx += 1
+    return result
+
+
+def _apply_unified_diff(prev, diff):
+    """Reconstruct a field's full value by applying a Salesforce CDC unified diff to
+    its previous value. Large text fields (>= 1000 chars) are sent as a unified diff
+    (named in diff_fields) instead of the full value.
+
+    Returns `prev` unchanged if the diff is missing/unparseable, or if the SHA-256 in
+    the `+++` header doesn't match the reconstructed value (so we never store corrupt
+    text — worst case we keep the last full value)."""
+    if diff is None:
+        return prev
+    # The field value may use CRLF line endings while the diff body uses LF. Split the
+    # prior value on its own terminator so line content matches the diff, and rejoin
+    # with the same terminator (the SHA-256 in the +++ header is over the CRLF form).
+    term = "\r\n" if (prev and "\r\n" in prev) else "\n"
+    prev_lines = [] if prev is None else prev.split(term)
+    try:
+        parsed = _parse_unified_diff(diff.split("\n"))
+        if parsed is None:
+            return prev
+        expected_hash, hunks = parsed
+        result_lines = _rebuild_from_hunks(prev_lines, hunks)
+        if result_lines is None:
+            return prev
+        result = term.join(result_lines)
+    except Exception:
+        return prev
+    if expected_hash and hashlib.sha256(result.encode("utf-8")).hexdigest() != expected_hash:
+        return prev
+    return result
+
+
+def _resolve_chain(prior, chain):
+    """Fold a record's per-batch change chain for one string column, in sequence
+    order, starting from the prior committed value. Each item is a full value (d=False)
+    or a unified diff to apply (d=True). Empty chain -> carry forward `prior`."""
+    if not chain:
+        return prior
+    items = sorted(chain, key=lambda r: (r["s"]["ts"], r["s"]["rid"] or ""))
+    cur = prior
+    for it in items:
+        cur = _apply_unified_diff(cur, it["v"]) if it["d"] else it["v"]
+    return cur
+
+
+def _collapse_batch(batch_df, business_cols, string_cols):
+    """Fold all events for a key within one micro-batch into a single combined delta.
+
+    Each event is itself a sparse delta, so we cannot just keep the latest event:
+    fields changed by earlier events in the same batch would be lost. Per column,
+    take the value from the latest event in which the column was actually touched.
+
+    String columns instead emit an ordered `__chain__c` of touching events (value +
+    is-diff flag) so the sink can fold full-value and unified-diff events in sequence
+    (a diff must apply to the prior value, which may be set earlier in the same batch).
+    """
+    mask = array_union(
+        array_union(col("changed_fields"), col("nulled_fields")), col("diff_fields")
+    )
+    seq = F.struct(col("timestamp").alias("ts"), col("replay_id").alias("rid"))
+    is_create_like = col("change_type").isin(*CREATE_LIKE)
+
+    d = (
+        batch_df.withColumn("Id", col("record_ids")[0])
+        .withColumn("_seq", seq)
+        .withColumn("_mask", mask)
+    )
+
+    aggs = []
+    for c in business_cols:
+        # A row "touches" c when c is named in the change mask, or it's a create-like
+        # event with a populated value (creates carry a full image, empty mask).
+        touched = array_contains(col("_mask"), lit(c)) | (is_create_like & col(f"`{c}`").isNotNull())
+        seq_c = F.when(touched, col("_seq"))  # null on rows that don't touch c
+        # Did c get touched at all in this batch?
+        aggs.append(F.max(seq_c).isNotNull().alias(f"__chg__{c}"))
+        if c in string_cols:
+            # ordered chain of touching events (value + whether it's a unified diff)
+            item = F.when(
+                touched,
+                F.struct(
+                    col("_seq").alias("s"),
+                    col(f"`{c}`").alias("v"),
+                    array_contains(col("diff_fields"), lit(c)).alias("d"),
+                ),
             )
-            .orderBy(desc("timestamp"))
-            .select("schema_json")
-            .first()[0]
+            aggs.append(F.collect_list(item).alias(f"__chain__{c}"))
+        else:
+            # Latest value among touched rows (null here = a genuine change-to-null).
+            aggs.append(max_by(col(f"`{c}`"), seq_c).alias(c))
+
+    aggs += [
+        max_by(col("change_type"), col("_seq")).alias("_last_change_type"),
+        max_by(col("replay_id"), col("_seq")).alias("_last_replay_id"),
+        F.max(col("timestamp")).alias("_last_event_ts"),
+    ]
+    return d.groupBy("Id").agg(*aggs)
+
+
+def _ensure_current_table(current_fqn: str, obj: str, schema_json: str):
+    """Create the Type-1 current-state table (CDF on) if it doesn't exist.
+
+    Called during graph evaluation so the table exists before Layer 2's CDF reader
+    is *analyzed* (SDP resolves all flows up front; a streaming read of a missing
+    table fails analysis, and the sink creating it later is too late). spark.sql
+    CREATE is forbidden during eval, but the DeltaTable builder API is allowed."""
+    # Resolve parsed Avro types without scanning data (from_avro types come from schema).
+    parsed_schema = _parse_avro(
+        dp.read(zerobus_table).filter(col("entity_name") == obj).limit(0), schema_json
+    ).schema
+    business_fields = [f for f in parsed_schema.fields if f.name not in META_COLS]
+    table_schema = StructType(
+        [StructField("Id", StringType())]
+        + business_fields
+        + [
+            StructField("_last_change_type", StringType()),
+            StructField("_last_replay_id", StringType()),
+            StructField("_last_event_ts", LongType()),
+            StructField("_updated_at", TimestampType()),
+        ]
+    )
+    (
+        DeltaTable.createIfNotExists(spark)
+        .tableName(current_fqn)
+        .addColumns(table_schema)
+        .property("delta.enableChangeDataFeed", "true")
+        .execute()
+    )
+
+
+def _merge_fn(current_fqn: str):
+    """Build the foreachBatch function that MERGEs each micro-batch into the
+    current-state table (created during graph eval by _ensure_current_table)."""
+
+    def _fn(batch_df, batch_id):
+        if batch_df.isEmpty():
+            return
+        spark_s = batch_df.sparkSession
+        spark_s.udf.register("resolve_chain", _resolve_chain, StringType())
+        # Only merge columns that exist in the target (guards against schema drift).
+        target_cols = set(spark_s.read.table(current_fqn).columns)
+        string_cols = {
+            f.name for f in batch_df.schema.fields if isinstance(f.dataType, StringType)
+        }
+        business_cols = [
+            c for c in batch_df.columns if c not in META_COLS and c in target_cols
+        ]
+        combined = _collapse_batch(
+            batch_df, business_cols, {c for c in business_cols if c in string_cols}
         )
 
-        df = df.select(
-            "*",
-            from_avro(
-                col("payload_binary"), latest_schema, {"mode": "PERMISSIVE"}
-            ).alias("parsed_data"),
+        tracking = {
+            "_last_change_type": "s._last_change_type",
+            "_last_replay_id": "s._last_replay_id",
+            "_last_event_ts": "s._last_event_ts",
+            "_updated_at": "current_timestamp()",
+        }
+        update_set, insert_values = {}, {"Id": "s.Id"}
+        for c in business_cols:
+            if c in string_cols:
+                # fold the change chain over the prior value (handles unified diffs);
+                # empty chain -> carry forward on update, NULL on insert
+                update_set[c] = f"resolve_chain(t.`{c}`, s.`__chain__{c}`)"
+                insert_values[c] = f"resolve_chain(CAST(NULL AS STRING), s.`__chain__{c}`)"
+            else:
+                # only overwrite when actually touched this batch
+                update_set[c] = f"CASE WHEN s.`__chg__{c}` THEN s.`{c}` ELSE t.`{c}` END"
+                insert_values[c] = f"CASE WHEN s.`__chg__{c}` THEN s.`{c}` ELSE NULL END"
+        update_set.update(tracking)
+        insert_values.update(tracking)
+
+        (
+            DeltaTable.forName(spark_s, current_fqn)
+            .alias("t")
+            .merge(combined.alias("s"), "t.Id = s.Id")
+            .whenMatchedDelete(condition="s._last_change_type = 'DELETE'")
+            .whenMatchedUpdate(set=update_set)
+            .whenNotMatchedInsert(condition="s._last_change_type <> 'DELETE'", values=insert_values)
+            .execute()
         )
-        return df.select("*", "parsed_data.*").drop("parsed_data")
+
+    return _fn
 
 
-zerobus_table = "<your_zerobus_table_name>"
+def create_pipeline(salesforce_object: str):
+    schema_json = _latest_schema_json(salesforce_object)
+    if schema_json is None:
+        return  # no payload for this object yet; nothing to build
+
+    safe = _safe(salesforce_object)
+    current_fqn = f"{CATALOG}.{SCHEMA}.salesforce_current_{safe}"
+    sink_name = f"current_sink_{safe}"
+    cdf_name = f"current_cdf_{safe}"
+    history_name = f"salesforce_history_{safe}"
+
+    # Create the current-state table now (graph eval) so Layer 2's CDF reader can be
+    # analyzed; the sink then MERGEs into it and Layer 2 streams its Change Data Feed.
+    _ensure_current_table(current_fqn, salesforce_object, schema_json)
+
+    # ---- Layer 1: parse Avro inline, MERGE into the Type-1 current-state table ----
+    # (defined inside create_pipeline, so each closes over this call's variables)
+    sink_merge = _merge_fn(current_fqn)
+
+    @dp.foreach_batch_sink(name=sink_name)
+    def _sink(df, batch_id):
+        sink_merge(df, batch_id)
+
+    @dp.append_flow(target=sink_name, name=f"{sink_name}_flow")
+    def _flow():
+        stream = dp.readStream(zerobus_table).filter(col("entity_name") == salesforce_object)
+        return _parse_avro(stream, schema_json)
+
+    # ---- Layer 2: SCD2 history from the current table's Change Data Feed ----
+    # temporary_view: pipeline-scoped, not materialized (no extra physical table)
+    @dp.temporary_view(name=cdf_name)
+    def _cdf():
+        # startingVersion=0 so the first run captures the full history of the current
+        # table (a streaming CDF read otherwise starts at the latest version and
+        # skips the initial backfill). Ignored once a checkpoint exists.
+        return (
+            spark.readStream.option("readChangeFeed", "true")
+            .option("startingVersion", "0")
+            .table(current_fqn)
+            .filter(col("_change_type").isin("insert", "update_postimage", "delete"))
+        )
+
+    dp.create_streaming_table(name=history_name)
+    dp.create_auto_cdc_flow(
+        target=history_name,
+        source=cdf_name,
+        keys=["Id"],
+        sequence_by=col("_commit_timestamp"),
+        stored_as_scd_type=2,
+        apply_as_deletes=expr("_change_type = 'delete'"),
+        except_column_list=["_change_type", "_commit_version", "_commit_timestamp"],
+        ignore_null_updates=False,
+    )
+
+
+# One set of flows/tables per Salesforce object present in bronze.
 salesforce_objects = [
-    sf_object.entity_name
-    for sf_object in dp.read(zerobus_table).select("entity_name").distinct().collect()
+    row.entity_name
+    for row in dp.read(zerobus_table).select("entity_name").distinct().collect()
 ]
 for salesforce_object in salesforce_objects:
     create_pipeline(salesforce_object)

--- a/salesforce_zerobus/core.py
+++ b/salesforce_zerobus/core.py
@@ -177,6 +177,12 @@ class SalesforceZerobus:
         self._flow_controller = None
         self._background_tasks = []
 
+        # Synchronization for the background Databricks init (table creation + replay
+        # resolution). The subscription must wait for this and reuse its replay
+        # decision; re-deriving it separately races table creation (see start()).
+        self._init_complete = threading.Event()
+        self._init_replay_params = None
+
         # Setup logging
         self.logger = logging.getLogger(f"{__name__}.{sf_object}")
 
@@ -309,45 +315,62 @@ class SalesforceZerobus:
 
     async def _initialize_databricks_async(self):
         """Initialize Databricks components for async operation."""
-        # First, ensure table exists and get subscription params (triggers table creation if needed)
-        if self._replay_manager:
-            # This call will create the table if it doesn't exist
-            replay_type, replay_id = self._replay_manager.get_subscription_params(
-                auto_create_table=self.auto_create_table,
-                backfill_historical=self.backfill_historical,
-            )
-            self.logger.debug(
-                f"Table initialization complete, replay mode: {replay_type}"
-            )
-
-            # Initialize replay recovery (pre-fetch replay_id to avoid blocking later)
-            self._replay_manager.initialize_replay_recovery()
-
-        # Now initialize the stream (table should exist at this point)
-        if self._databricks_forwarder:
-            await self._databricks_forwarder.initialize_stream()
-            self.logger.info("Databricks stream initialized")
-
-    def _get_subscription_params(self):
-        """Get replay parameters for subscription (table should already exist from async init)."""
-        if self._replay_manager:
-            try:
-                # Table should already exist from _initialize_databricks_async, so just get the params
+        try:
+            # First, ensure table exists and get subscription params (triggers table creation if needed)
+            if self._replay_manager:
+                # This call will create the table if it doesn't exist
                 replay_type, replay_id = self._replay_manager.get_subscription_params(
-                    auto_create_table=False,  # Don't create table again
+                    auto_create_table=self.auto_create_table,
                     backfill_historical=self.backfill_historical,
                 )
-                if replay_type == "CUSTOM":
-                    self.logger.info(f"Resuming from replay_id: {replay_id}")
-                elif replay_type == "EARLIEST":
-                    self.logger.info("Starting historical backfill from EARLIEST")
-                else:
-                    self.logger.info("Starting fresh subscription from LATEST")
-                return replay_type, replay_id
+                # Cache the resolved decision so the subscription reuses it rather than
+                # re-deriving with auto_create_table=False (which races table creation
+                # and can wrongly fall back to LATEST, skipping the backfill).
+                self._init_replay_params = (replay_type, replay_id)
+                self.logger.debug(
+                    f"Table initialization complete, replay mode: {replay_type}"
+                )
+
+                # Initialize replay recovery (pre-fetch replay_id to avoid blocking later)
+                self._replay_manager.initialize_replay_recovery()
+
+            # Now initialize the stream (table should exist at this point)
+            if self._databricks_forwarder:
+                await self._databricks_forwarder.initialize_stream()
+                self.logger.info("Databricks stream initialized")
+        finally:
+            # Always signal completion so a waiting start() never blocks forever,
+            # even if initialization raised partway through.
+            self._init_complete.set()
+
+    def _get_subscription_params(self):
+        """Get replay parameters for the subscription.
+
+        Prefers the decision already computed by _initialize_databricks_async, which
+        owns table creation and may select EARLIEST/CUSTOM. Only re-derives here (with
+        auto_create_table=False) if that init step produced no result, since re-deriving
+        races table creation and can wrongly fall back to LATEST."""
+        if self._init_replay_params is not None:
+            replay_type, replay_id = self._init_replay_params
+        elif self._replay_manager:
+            try:
+                replay_type, replay_id = self._replay_manager.get_subscription_params(
+                    auto_create_table=False,  # init path owns table creation
+                    backfill_historical=self.backfill_historical,
+                )
             except Exception as e:
                 self.logger.warning(f"Replay manager failed, using LATEST: {e}")
+                replay_type, replay_id = "LATEST", ""
+        else:
+            replay_type, replay_id = "LATEST", ""
 
-        return "LATEST", ""
+        if replay_type == "CUSTOM":
+            self.logger.info(f"Resuming from replay_id: {replay_id}")
+        elif replay_type == "EARLIEST":
+            self.logger.info("Starting historical backfill from EARLIEST")
+        else:
+            self.logger.info("Starting fresh subscription from LATEST")
+        return replay_type, replay_id
 
     def _salesforce_event_callback(self, event, pubsub):
         """Callback for processing Salesforce events."""
@@ -594,9 +617,15 @@ class SalesforceZerobus:
             self.async_thread = threading.Thread(target=run_async, daemon=True)
             self.async_thread.start()
 
-            import time
-
-            time.sleep(2)
+            # Wait for the background init (table creation + replay-mode resolution) to
+            # finish before resolving subscription params. A fixed sleep here used to
+            # race table creation: on a slow/cold warehouse the table didn't exist yet,
+            # so the subscription fell back to LATEST and silently skipped the backfill.
+            if not self._init_complete.wait(timeout=120):
+                self.logger.warning(
+                    "Databricks initialization did not complete within 120s; "
+                    "proceeding (subscription may fall back to LATEST)"
+                )
             self.logger.info("Databricks connection initialized")
 
             replay_type, replay_id = self._get_subscription_params()

--- a/tests/test_replay_init_race.py
+++ b/tests/test_replay_init_race.py
@@ -1,0 +1,107 @@
+"""Tests for the SalesforceZerobus startup-race fix in salesforce_zerobus/core.py.
+
+Background: `start()` used to `time.sleep(2)` and then resolve the subscription's replay
+mode with `auto_create_table=False`. On a slow/cold warehouse the background table-init
+hadn't finished, so the table didn't exist yet and the subscription fell back to LATEST,
+silently skipping the historical backfill. The fix waits on `_init_complete` and has the
+subscription reuse the replay decision the init path already computed
+(`_init_replay_params`).
+
+These tests build a bare SalesforceZerobus (bypassing the heavy __init__) and drive the
+two methods directly with a fake replay manager.
+
+Run with the project venv (core.py imports avro/grpc/zerobus):
+    .venv/bin/python tests/test_replay_init_race.py
+Or:  .venv/bin/python -m pytest tests/test_replay_init_race.py
+"""
+
+import asyncio
+import logging
+import threading
+import time
+
+from salesforce_zerobus.core import SalesforceZerobus
+
+logging.disable(logging.CRITICAL)
+
+
+class _FakeReplayManager:
+    """Mimics the race: creating the table (auto_create_table=True) is slow and yields
+    EARLIEST; the no-create path (the old subscription call) returns LATEST."""
+
+    def __init__(self, create_delay=0.5, raises=False):
+        self.create_delay = create_delay
+        self.raises = raises
+
+    def get_subscription_params(self, auto_create_table, backfill_historical):
+        if self.raises:
+            raise RuntimeError("simulated init failure")
+        if auto_create_table:
+            time.sleep(self.create_delay)  # slow CREATE TABLE on a cold warehouse
+            return ("EARLIEST", "")
+        return ("LATEST", "")  # table not there yet -> fallback
+
+    def initialize_replay_recovery(self):
+        pass
+
+
+def _bare_streamer(replay_manager):
+    s = object.__new__(SalesforceZerobus)  # skip __init__ (needs real auth/config)
+    s.logger = logging.getLogger("test")
+    s._replay_manager = replay_manager
+    s._databricks_forwarder = None
+    s.auto_create_table = True
+    s.backfill_historical = True
+    s._init_complete = threading.Event()
+    s._init_replay_params = None
+    return s
+
+
+def test_subscription_waits_and_uses_earliest():
+    """The fix: wait for the slow init, then reuse its EARLIEST decision (not LATEST)."""
+    s = _bare_streamer(_FakeReplayManager(create_delay=0.5))
+    threading.Thread(target=lambda: asyncio.run(s._initialize_databricks_async()), daemon=True).start()
+
+    assert s._init_complete.wait(timeout=10), "init never signalled completion"
+    assert s._init_replay_params == ("EARLIEST", "")
+    assert s._get_subscription_params() == ("EARLIEST", "")
+
+
+def test_no_wait_would_fall_back_to_latest():
+    """Guard documenting the original bug: resolving before init cached a result hits the
+    auto_create_table=False path, which returns LATEST."""
+    s = _bare_streamer(_FakeReplayManager())
+    # init has NOT run, so _init_replay_params is still None
+    assert s._init_replay_params is None
+    assert s._get_subscription_params() == ("LATEST", "")
+
+
+def test_custom_resume_is_preserved():
+    """When init resolves to a stored replay_id, restarts resume (CUSTOM), not re-backfill."""
+    s = _bare_streamer(_FakeReplayManager())
+    s._init_replay_params = ("CUSTOM", "REPLAYID123")
+    assert s._get_subscription_params() == ("CUSTOM", "REPLAYID123")
+
+
+def test_init_signals_completion_even_on_error():
+    """_init_complete must be set in a finally so start() never blocks forever."""
+    s = _bare_streamer(_FakeReplayManager(raises=True))
+    try:
+        asyncio.run(s._initialize_databricks_async())
+    except RuntimeError:
+        pass
+    assert s._init_complete.is_set()
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {t.__name__}: {e!r}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    raise SystemExit(1 if failures else 0)

--- a/tests/test_unified_diff.py
+++ b/tests/test_unified_diff.py
@@ -1,0 +1,114 @@
+"""Tests for the unified-diff reconstruction in lakeflow_declarative_pipeline.py.
+
+These cover `_parse_unified_diff` / `_rebuild_from_hunks` / `_apply_unified_diff`,
+which rebuild a large text field from the unified diff Salesforce CDC sends for it.
+
+The pipeline module imports pyspark + dlt at the top, which aren't importable outside
+a Databricks runtime, so we load just the three pure functions (and the `_HUNK_RE`
+module global they use) out of the source via AST instead of importing the module.
+
+Run standalone (no pytest needed):  python tests/test_unified_diff.py
+Or with pytest if available:        pytest tests/test_unified_diff.py
+"""
+
+import ast
+import hashlib
+import pathlib
+import re
+
+_SRC = pathlib.Path(__file__).resolve().parent.parent / "lakeflow_declarative_pipeline.py"
+
+
+def _load_diff_functions():
+    """Exec only the diff helpers (+ the _HUNK_RE global) from the pipeline source."""
+    tree = ast.parse(_SRC.read_text())
+    wanted = {"_parse_unified_diff", "_rebuild_from_hunks", "_apply_unified_diff"}
+    keep = [
+        node
+        for node in tree.body
+        if (isinstance(node, ast.FunctionDef) and node.name in wanted)
+        or (
+            isinstance(node, ast.Assign)
+            and any(getattr(t, "id", None) == "_HUNK_RE" for t in node.targets)
+        )
+    ]
+    namespace = {"re": re, "hashlib": hashlib}
+    exec(compile(ast.Module(body=keep, type_ignores=[]), str(_SRC), "exec"), namespace)
+    return namespace
+
+
+_NS = _load_diff_functions()
+apply_unified_diff = _NS["_apply_unified_diff"]
+
+
+def _make_diff(new_value, hunk_header, body_lines, term="\n", bad_hash=False):
+    """Build a unified-diff string whose +++ header carries sha256(new_value)."""
+    digest = "deadbeef" if bad_hash else hashlib.sha256(new_value.encode("utf-8")).hexdigest()
+    return "\n".join(["--- old", f"+++ {digest}", hunk_header, *body_lines])
+
+
+def test_apply_add_remove_context():
+    prev = "line1\nline2\nline3"
+    new = "line1\nLINE2\nline3\nline4"
+    diff = _make_diff(new, "@@ -1,3 +1,4 @@", [" line1", "-line2", "+LINE2", " line3", "+line4"])
+    assert apply_unified_diff(prev, diff) == new
+
+
+def test_multi_hunk():
+    prev = "1\n2\n3\n4\n5\n6"
+    new = "1\nX\n3\n4\nY\n6"
+    diff = _make_diff(
+        new,
+        "@@ -1,2 +1,2 @@",
+        [" 1", "-2", "+X", "@@ -4,3 +4,3 @@", " 4", "-5", "+Y", " 6"],
+    )
+    assert apply_unified_diff(prev, diff) == new
+
+
+def test_crlf_is_preserved():
+    # Prior value uses CRLF; the diff body is LF-separated but content joins back with CRLF
+    # (the sha256 in the +++ header is over the CRLF form).
+    prev = "a\r\nb\r\nc"
+    new = "a\r\nB\r\nc"
+    diff = _make_diff(new, "@@ -1,3 +1,3 @@", [" a", "-b", "+B", " c"])
+    assert apply_unified_diff(prev, diff) == new
+
+
+def test_bad_hash_keeps_prev():
+    prev = "line1\nline2\nline3"
+    new = "line1\nLINE2\nline3"
+    diff = _make_diff(new, "@@ -1,3 +1,3 @@", [" line1", "-line2", "+LINE2", " line3"], bad_hash=True)
+    # Reconstructed value's hash won't match the (tampered) header -> keep the prior value.
+    assert apply_unified_diff(prev, diff) == prev
+
+
+def test_none_diff_keeps_prev():
+    prev = "anything"
+    assert apply_unified_diff(prev, None) == prev
+
+
+def test_malformed_hunk_keeps_prev():
+    prev = "line1\nline2"
+    assert apply_unified_diff(prev, "--- old\n+++ x\n@@ not a real header @@\n+z") == prev
+
+
+def test_unrecognized_body_line_keeps_prev():
+    prev = "line1\nline2"
+    new = "line1\nline2"
+    # A body line that isn't ' '/'-'/'+' (here '!') makes _rebuild_from_hunks bail -> keep prev.
+    diff = _make_diff(new, "@@ -1,2 +1,2 @@", [" line1", "!bogus", " line2"])
+    assert apply_unified_diff(prev, diff) == prev
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {t.__name__}: {e!r}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    raise SystemExit(1 if failures else 0)


### PR DESCRIPTION
## Summary

Adds an accurate current-state + SCD2 history Lakeflow pipeline for the streamed
Salesforce CDC data, fixes a startup race in the streamer that could silently skip the
historical backfill, and brings the repo its first automated tests + CI.

## Changes

### Streaming reliability fix (`salesforce_zerobus/core.py`)
`start()` used a fixed `time.sleep(2)` to wait for background Databricks
initialization, then resolved the subscription's replay mode with
`auto_create_table=False`. On a slow/cold SQL warehouse, table creation hadn't finished
within 2s, so the table didn't exist yet, the lookup fell back to **LATEST**, and the
historical **backfill was silently skipped** (it only picked up new events).

The fix replaces the sleep with a `threading.Event` the init path sets on completion,
and has the subscription **reuse the replay decision init already computed**
(EARLIEST / CUSTOM) instead of re-deriving it. Result: deterministic startup regardless
of warehouse latency, and resume-from-`replay_id` (CUSTOM) is preserved across restarts.

### Lakeflow pipeline: accurate current state + SCD2 history (`lakeflow_declarative_pipeline.py`, `README.md`)
Maintains, per Salesforce object, a Type-1 `salesforce_current_<obj>` table (via a
per-column conditional MERGE that correctly distinguishes *unchanged* from
*changed-to-null* using the CDC change mask) and an SCD2 `salesforce_history_<obj>`
table from that table's Change Data Feed. Notable details:
- Large text fields arrive as unified diffs; reconstruction is split into
  `_parse_unified_diff` + `_rebuild_from_hunks` + `_apply_unified_diff` for readability,
  with a SHA-256 guard so a bad/garbled diff falls back to the last full value.
- SCD2 is sequenced by **`_commit_timestamp`** so `__START_AT` / `__END_AT` are real
  effective-dating windows rather than opaque Delta version integers.
- Documents the one-update lag between Layer 1 and the SCD2 history flow.

### Tests (`tests/`)
First tests in the repo:
- `test_unified_diff.py` — add/remove/context + multi-hunk diffs, CRLF preservation, and
  the keep-prior-value guards (bad SHA-256, `None`, malformed hunk, unrecognized line).
  Loads the pure diff helpers via AST, so it runs without pyspark/dlt.
- `test_replay_init_race.py` — the subscription waits for init and reuses EARLIEST,
  documents the old LATEST fallback, preserves CUSTOM resume, and signals completion even
  on error.

### CI (`.github/workflows/tests.yml`)
Runs `pip install -e ".[dev]"` then `pytest tests/ -v` on every push and pull request.

## Verification
- Race tests fail against the pre-fix `core.py` (3/4), pass after the fix (4/4).
- Diff tests pass on the current code and catch an injected reconstruction regression
  (3/7 fail when removal handling is broken), confirming they're not vacuous.
- CI is green.